### PR TITLE
Fix Reference Error when fetch is unsuccessful

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -435,7 +435,7 @@ class Client extends EventEmitter {
 				throw new Error('An internal error occur: '+internal_error_step);
 			}
 		}else{
-			throw new Error('Can\'t get the keys : '+error);
+			throw new Error('Can\'t get the keys : '+result.error);
 		}
 	}
 


### PR DESCRIPTION
If `fetch.success` is `false` it will throw `ReferenceError: error is not defined` instead of `Can't get the keys`